### PR TITLE
Feature/bitmap reduce colours

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(libs.androidx.adaptive.layout)
     implementation(libs.androidx.adaptive.navigation)
     testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/de/berlindroid/zepatch/Holzmesser.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/Holzmesser.kt
@@ -3,6 +3,7 @@ package de.berlindroid.zepatch
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import de.berlindroid.zepatch.patchable.Demo
+import de.berlindroid.zepatch.patchable.GradientBall
 
 /**
  * It's like Dagger, but way worse.
@@ -30,5 +31,6 @@ val patchables = mapOf<String, @Composable () -> Unit>(
     "Testing16" to { BasicText("123") },
     "Testing17" to { BasicText("123") },
     "Testing19" to { BasicText("123") },
+    "GradientBall" to { GradientBall() },
     "Demo" to { Demo() },
 )

--- a/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -47,9 +46,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
+import de.berlindroid.zepatch.ui.PatchableBoundingBox
+import de.berlindroid.zepatch.ui.PatchableToBitmap
 import de.berlindroid.zepatch.ui.theme.ZePatchTheme
 import kotlinx.coroutines.launch
 
@@ -159,20 +159,6 @@ private fun PatchableList(
     }
 }
 
-@Composable
-private fun PatchableBoundingBox(
-    modifier: Modifier = Modifier,
-    patchable: @Composable () -> Unit
-) {
-    Box(
-        modifier = modifier.border(
-            width = 1.dp,
-            color = Color.Black,
-        ),
-    ) {
-        patchable()
-    }
-}
 
 @ExperimentalMaterial3Api
 @Composable
@@ -229,12 +215,12 @@ private fun PatchableDetail(
             }
             when (currentMode) {
                 PatchablePreviewMode.COMPOSABLE -> PatchableBoundingBox(patchable = patchable)
-                PatchablePreviewMode.TBD -> Text("Not implemented")
+                PatchablePreviewMode.BITMAP -> PatchableToBitmap(patchable = patchable)
             }
         }
     }
 }
 
 private enum class PatchablePreviewMode {
-    COMPOSABLE, TBD
+    COMPOSABLE, BITMAP
 }

--- a/app/src/main/java/de/berlindroid/zepatch/patchable/Demo.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/patchable/Demo.kt
@@ -1,12 +1,10 @@
 package de.berlindroid.zepatch.patchable
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import de.berlindroid.zepatch.ui.SafeArea
 
 @Composable
 fun Demo(
@@ -17,21 +15,8 @@ fun Demo(
     }
 }
 
-// TODO: share this?
-@Composable
-fun SafeArea(
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
-    Box(
-        modifier = modifier.padding(32.dp),
-    ) {
-        content()
-    }
-}
-
 @Preview
 @Composable
 fun PreviewDemo() {
-
+    Demo()
 }

--- a/app/src/main/java/de/berlindroid/zepatch/patchable/GradientBall.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/patchable/GradientBall.kt
@@ -1,0 +1,67 @@
+package de.berlindroid.zepatch.patchable
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import de.berlindroid.zepatch.ui.SafeArea
+
+/**
+ * Draws a circular ball with a retro-style vertical gradient consisting of
+ * Cyan (top), Pink (middle), and Purple (bottom) bands with transparent gaps.
+ */
+@Composable
+fun GradientBall(
+    modifier: Modifier = Modifier,
+    topColor: Color = Color.Cyan,
+    middleColor: Color = Color(0xFFFF69B4), // Pink
+    bottomColor: Color = Color(0xFF800080), // Purple
+) {
+    SafeArea {
+        Canvas(modifier = modifier.size(56.dp)) {
+            val height = size.height
+            val brushRetro = Brush.verticalGradient(
+                colorStops = arrayOf(
+                    0.0f to topColor,
+                    0.43f to topColor,
+                    0.43f to Color.Transparent,
+                    0.45f to Color.Transparent,
+                    0.45f to topColor,
+                    0.57f to middleColor,
+                    0.57f to Color.Transparent,
+                    0.6f to Color.Transparent,
+                    0.6f to middleColor,
+                    0.7f to middleColor,
+                    0.7f to Color.Transparent,
+                    0.74f to Color.Transparent,
+                    0.74f to middleColor,
+                    0.84f to bottomColor,
+                    0.84f to Color.Transparent,
+                    0.9f to Color.Transparent,
+                    0.9f to bottomColor,
+                    1.0f to bottomColor
+                ),
+                startY = 0f,
+                endY = height
+            )
+
+            val radius = size.minDimension / 2f
+            drawCircle(
+                brush = brushRetro,
+                radius = radius,
+                center = Offset(size.width / 2f, size.height / 2f)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewGradientBall() {
+    GradientBall(modifier = Modifier.size(200.dp))
+}

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
@@ -1,7 +1,12 @@
 package de.berlindroid.zepatch.ui
 
+import android.graphics.Bitmap
+import android.util.Log
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
@@ -10,8 +15,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.asImageBitmap
 import de.berlindroid.zepatch.utils.CaptureToBitmap
+import de.berlindroid.zepatch.utils.reduceColors
 
 /**
  * Renders the provided [patchable] into a Bitmap-like [ImageBitmap] and displays it via [Image].
@@ -24,7 +33,7 @@ fun PatchableToBitmap(
 ) {
     var image by remember { mutableStateOf<ImageBitmap?>(null) }
 
-    Box(modifier = modifier.fillMaxWidth()) {
+    Column(modifier = modifier.fillMaxWidth()) {
         // Compose the content through the composable utility; it will invoke the callback when ready.
         CaptureToBitmap(
             modifier = Modifier.fillMaxWidth(),
@@ -33,11 +42,31 @@ fun PatchableToBitmap(
             content = patchable
         )
 
-        val b = image
-        if (b != null) {
-            Image(bitmap = b, contentDescription = "patch bitmap", modifier = Modifier.fillMaxWidth())
+        val imageBitmap = image
+        if (imageBitmap != null) {
+            val reducedBitmap: ImageBitmap? = remember(imageBitmap) {
+                try {
+                    imageBitmap
+                        .asAndroidBitmap().copy(Bitmap.Config.ARGB_8888, true)
+                        .reduceColors(3)
+                        .asImageBitmap()
+                } catch (t: Throwable) {
+                    Log.e("PatchableToBitmap", "Error ${t.message}")
+                    null
+                }
+            }
+
+            reducedBitmap?.let {
+                Image(
+                    bitmap = it,
+                    contentDescription = "patch bitmap reduced to 3 colors",
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
         } else {
             CircularProgressIndicator()
         }
     }
 }
+

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBitmap.kt
@@ -1,0 +1,43 @@
+package de.berlindroid.zepatch.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import de.berlindroid.zepatch.utils.CaptureToBitmap
+
+/**
+ * Renders the provided [patchable] into a Bitmap-like [ImageBitmap] and displays it via [Image].
+ * Uses a composable utility that captures the composed content from a graphics layer.
+ */
+@Composable
+fun PatchableToBitmap(
+    modifier: Modifier = Modifier,
+    patchable: @Composable () -> Unit,
+) {
+    var image by remember { mutableStateOf<ImageBitmap?>(null) }
+
+    Box(modifier = modifier.fillMaxWidth()) {
+        // Compose the content through the composable utility; it will invoke the callback when ready.
+        CaptureToBitmap(
+            modifier = Modifier.fillMaxWidth(),
+            autoCapture = true,
+            onBitmap = { img -> image = img },
+            content = patchable
+        )
+
+        val b = image
+        if (b != null) {
+            Image(bitmap = b, contentDescription = "patch bitmap", modifier = Modifier.fillMaxWidth())
+        } else {
+            CircularProgressIndicator()
+        }
+    }
+}

--- a/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBoundingBox.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/PatchableToBoundingBox.kt
@@ -1,0 +1,23 @@
+package de.berlindroid.zepatch.ui
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PatchableBoundingBox(
+    modifier: Modifier = Modifier,
+    patchable: @Composable () -> Unit
+) {
+    Box(
+        modifier = modifier.border(
+            width = 1.dp,
+            color = Color.Black,
+        ),
+    ) {
+        patchable()
+    }
+}

--- a/app/src/main/java/de/berlindroid/zepatch/ui/SafeArea.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/ui/SafeArea.kt
@@ -1,0 +1,22 @@
+package de.berlindroid.zepatch.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Common SafeArea wrapper to provide consistent padding around patchable content.
+ */
+@Composable
+fun SafeArea(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier.padding(32.dp),
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/de/berlindroid/zepatch/utils/BitmapUtils.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/utils/BitmapUtils.kt
@@ -2,12 +2,8 @@ package de.berlindroid.zepatch.utils
 
 import android.graphics.Bitmap
 import android.graphics.Color
-import kotlin.math.abs
 import kotlin.math.max
-import kotlin.math.min
-import kotlin.math.pow
 import kotlin.math.roundToInt
-import kotlin.math.sqrt
 
 /**
  * Reduces the number of colors in this [Bitmap] using a simple k-means quantization on RGB.

--- a/app/src/main/java/de/berlindroid/zepatch/utils/BitmapUtils.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/utils/BitmapUtils.kt
@@ -1,0 +1,170 @@
+package de.berlindroid.zepatch.utils
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.sqrt
+
+/**
+ * Reduces the number of colors in this [Bitmap] using a simple k-means quantization on RGB.
+ *
+ * Rules:
+ * - Only fully transparent pixels (alpha == 0) are ignored during palette computation.
+ * - Fully transparent pixels are kept as-is in the result.
+ * - Non-transparent pixels keep their original alpha while their RGB is mapped to the nearest palette color.
+ *
+ * Notes:
+ * - This returns a new immutable Bitmap; the original is not modified.
+ * - For tiny images or when the number of distinct colors is already <= [numColors],
+ *   it will effectively keep original colors (except it copies into a new Bitmap).
+ */
+fun Bitmap.reduceColors(numColors: Int): Bitmap {
+    val width = this.width
+    val height = this.height
+    if (width == 0 || height == 0) return this
+
+    val requested = max(1, numColors)
+
+    val pixels = IntArray(width * height)
+    this.getPixels(pixels, 0, width, 0, 0, width, height)
+
+    // Collect non-transparent colors (alpha > 0) for clustering
+    val opaqueColors = ArrayList<Int>(pixels.size)
+    for (c in pixels) {
+        if (Color.alpha(c) != 0) opaqueColors.add(c)
+    }
+
+    // If there are no opaque colors, just return a copy
+    if (opaqueColors.isEmpty()) {
+        return this.copy(this.config ?: Bitmap.Config.ARGB_8888, /*isMutable*/ false)
+    }
+
+    // Build a set of distinct opaque colors to potentially short-circuit
+    val distinct = LinkedHashSet<Int>(opaqueColors.size)
+    distinct.addAll(opaqueColors)
+
+    val palette: List<Int> = if (distinct.size <= requested) {
+        // Already within target; use the distinct colors themselves as palette
+        distinct.toList()
+    } else {
+        // Run a lightweight k-means on RGB
+        kMeansPalette(distinct.toList(), requested)
+    }
+
+    // Map every non-transparent pixel to nearest palette color (preserving original alpha)
+    val out = IntArray(pixels.size)
+    for (i in pixels.indices) {
+        val c = pixels[i]
+        val a = Color.alpha(c)
+        if (a == 0) {
+            out[i] = c // keep fully transparent as-is
+        } else {
+            val rgb = c and 0x00FFFFFF
+            val nearest = findNearest(rgb, palette)
+            val r = Color.red(nearest)
+            val g = Color.green(nearest)
+            val b = Color.blue(nearest)
+            out[i] = Color.argb(a, r, g, b)
+        }
+    }
+
+    val result = Bitmap.createBitmap(width, height, this.config ?: Bitmap.Config.ARGB_8888)
+    result.setPixels(out, 0, width, 0, 0, width, height)
+    return result
+}
+
+private fun kMeansPalette(colors: List<Int>, k: Int): List<Int> {
+    // Initialize centroids by picking k evenly spaced colors from the input list
+    val n = colors.size
+    val centroids = MutableList(k) { idx ->
+        val pos = ((idx.toLong() * n) / k).toInt().coerceIn(0, n - 1)
+        colors[pos]
+    }
+
+    val assignments = IntArray(n) { -1 }
+
+    repeat(10) { // small, fixed iteration count for speed/determinism
+        var changed = false
+
+        // Assign step
+        for (i in 0 until n) {
+            val color = colors[i] and 0x00FFFFFF
+            var best = 0
+            var bestDist = Double.POSITIVE_INFINITY
+            for (cIdx in 0 until k) {
+                val dist = rgbDistance(color, centroids[cIdx] and 0x00FFFFFF)
+                if (dist < bestDist) {
+                    bestDist = dist
+                    best = cIdx
+                }
+            }
+            if (assignments[i] != best) {
+                assignments[i] = best
+                changed = true
+            }
+        }
+
+        // If nothing changed, we're done
+        if (!changed) return@repeat
+
+        // Update step
+        val sumR = IntArray(k)
+        val sumG = IntArray(k)
+        val sumB = IntArray(k)
+        val counts = IntArray(k)
+
+        for (i in 0 until n) {
+            val idx = assignments[i]
+            val c = colors[i]
+            sumR[idx] += Color.red(c)
+            sumG[idx] += Color.green(c)
+            sumB[idx] += Color.blue(c)
+            counts[idx] += 1
+        }
+
+        for (cIdx in 0 until k) {
+            if (counts[cIdx] == 0) {
+                // Reinitialize empty cluster to a random-ish color from input to avoid dead cluster
+                val fallback = colors[(cIdx * 997) % n]
+                centroids[cIdx] = fallback
+            } else {
+                val r = (sumR[cIdx].toDouble() / counts[cIdx]).roundToInt().coerceIn(0, 255)
+                val g = (sumG[cIdx].toDouble() / counts[cIdx]).roundToInt().coerceIn(0, 255)
+                val b = (sumB[cIdx].toDouble() / counts[cIdx]).roundToInt().coerceIn(0, 255)
+                centroids[cIdx] = Color.rgb(r, g, b)
+            }
+        }
+    }
+
+    return centroids
+}
+
+private fun findNearest(rgb: Int, palette: List<Int>): Int {
+    var best = palette[0]
+    var bestDist = Double.POSITIVE_INFINITY
+    for (p in palette) {
+        val d = rgbDistance(rgb, p and 0x00FFFFFF)
+        if (d < bestDist) {
+            bestDist = d
+            best = p
+        }
+    }
+    return best
+}
+
+private fun rgbDistance(c1: Int, c2: Int): Double {
+    val r1 = (c1 shr 16) and 0xFF
+    val g1 = (c1 shr 8) and 0xFF
+    val b1 = c1 and 0xFF
+    val r2 = (c2 shr 16) and 0xFF
+    val g2 = (c2 shr 8) and 0xFF
+    val b2 = c2 and 0xFF
+    val dr = (r1 - r2).toDouble()
+    val dg = (g1 - g2).toDouble()
+    val db = (b1 - b2).toDouble()
+    return dr * dr + dg * dg + db * db
+}

--- a/app/src/main/java/de/berlindroid/zepatch/utils/CaptureToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/utils/CaptureToBitmap.kt
@@ -66,7 +66,6 @@ fun CaptureToBitmap(
                     onBitmap(bitmap)
                 }
             }
-            .background(Color.White)
     ) {
         content()
     }

--- a/app/src/main/java/de/berlindroid/zepatch/utils/CaptureToBitmap.kt
+++ b/app/src/main/java/de/berlindroid/zepatch/utils/CaptureToBitmap.kt
@@ -1,0 +1,73 @@
+package de.berlindroid.zepatch.utils
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import kotlinx.coroutines.launch
+
+/**
+ * Composable utility that renders [content] into a compositing graphics layer and can
+ * capture it into an [ImageBitmap].
+ *
+ * How it works:
+ * - We draw the composable's content into a remembered graphics layer using drawWithContent.
+ * - We then draw that content normally so it appears on screen.
+ * - We can capture the current pixels of that layer via graphicsLayer.toImageBitmap().
+ *
+ * Behavior:
+ * - If [autoCapture] is true, it will capture once on first composition and invoke [onBitmap].
+ * - It also supports manual capture by tapping the content (clickable), which will invoke [onBitmap].
+ */
+@Composable
+fun CaptureToBitmap(
+    modifier: Modifier = Modifier,
+    autoCapture: Boolean = true,
+    onBitmap: (ImageBitmap) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val graphicsLayer = rememberGraphicsLayer()
+    var captured by remember { mutableStateOf(false) }
+
+    // Optionally capture once after first composition
+    LaunchedEffect(autoCapture) {
+        if (autoCapture && !captured) {
+            captured = true
+            val capturedImage = graphicsLayer.toImageBitmap()
+            onBitmap(capturedImage)
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .drawWithContent {
+                // Record content drawing into the graphics layer
+                graphicsLayer.record {
+                    this@drawWithContent.drawContent()
+                }
+                // Draw the content normally so it appears on screen
+                this.drawContent()
+            }
+            .clickable {
+                coroutineScope.launch {
+                    val bitmap = graphicsLayer.toImageBitmap()
+                    onBitmap(bitmap)
+                }
+            }
+            .background(Color.White)
+    ) {
+        content()
+    }
+}

--- a/app/src/test/java/de/berlindroid/zepatch/utils/BitmapUtilsTest.kt
+++ b/app/src/test/java/de/berlindroid/zepatch/utils/BitmapUtilsTest.kt
@@ -1,0 +1,78 @@
+package de.berlindroid.zepatch.utils
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BitmapUtilsTest {
+
+    @Test
+    fun reduceColors_keepsTransparentPixelsUnchanged() {
+        val bmp = Bitmap.createBitmap(4, 1, Bitmap.Config.ARGB_8888)
+        val pixels = intArrayOf(
+            Color.RED,
+            Color.GREEN,
+            Color.BLUE,
+            Color.TRANSPARENT
+        )
+        bmp.setPixels(pixels, 0, 4, 0, 0, 4, 1)
+
+        val reduced = bmp.reduceColors(2)
+
+        val out = IntArray(4)
+        reduced.getPixels(out, 0, 4, 0, 0, 4, 1)
+
+        // last pixel should remain fully transparent
+        assertEquals(0, Color.alpha(out[3]))
+    }
+
+    @Test
+    fun reduceColors_reducesDistinctOpaqueColors() {
+        val bmp = Bitmap.createBitmap(6, 1, Bitmap.Config.ARGB_8888)
+        val pixels = intArrayOf(
+            Color.RED,           // R
+            Color.GREEN,         // G
+            Color.BLUE,          // B
+            Color.YELLOW,        // Y
+            Color.CYAN,          // C
+            Color.MAGENTA        // M
+        )
+        bmp.setPixels(pixels, 0, 6, 0, 0, 6, 1)
+
+        val reduced = bmp.reduceColors(2)
+
+        val out = IntArray(6)
+        reduced.getPixels(out, 0, 6, 0, 0, 6, 1)
+
+        // Count distinct non-transparent RGB colors in output
+        val distinct = out.filter { Color.alpha(it) != 0 }
+            .map { it and 0x00FFFFFF }
+            .toSet()
+
+        assertTrue("Expected at most 2 distinct non-transparent colors, got ${distinct.size}", distinct.size <= 2)
+    }
+
+    @Test
+    fun reduceColors_preservesAlphaForNonTransparentPixels() {
+        val bmp = Bitmap.createBitmap(2, 1, Bitmap.Config.ARGB_8888)
+        val semiAlphaRed = Color.argb(128, 255, 0, 0)
+        val pixels = intArrayOf(
+            semiAlphaRed,
+            Color.BLUE
+        )
+        bmp.setPixels(pixels, 0, 2, 0, 0, 2, 1)
+
+        val reduced = bmp.reduceColors(1)
+
+        val out = IntArray(2)
+        reduced.getPixels(out, 0, 2, 0, 0, 2, 1)
+
+        // Alpha of first pixel should remain 128 (semi-transparent)
+        assertEquals(128, Color.alpha(out[0]))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2025.06.01"
+robolectric = "4.15.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,6 +28,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-adaptive = { group = "androidx.compose.material3.adaptive", name = "adaptive" }
 androidx-adaptive-layout = { group = "androidx.compose.material3.adaptive", name = "adaptive-layout" }
 androidx-adaptive-navigation = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This branch would be an incremental change built on top of the capture to bitmap branch. 

# Description

A simple utility to reduce the colours of the bitmap as an extension function on `Bitmap`. It takes the number of colours you want as a parameter and it ignores transparent colours.

# Test
Unit tests are included. For a visual test, there is a simple sample `GradientBall` composable to see the colour reduction in action. When the GradientBall is converted to a bitmap it is further displayed with reduced colours.

| Original | 2 colours | 3 colours | 4 colours |
|------:|:-----:|:-----:|:------|
| <img width="100" alt="Screenshot 2025-08-16 at 18 11 33" src="https://github.com/user-attachments/assets/1f5d3f8e-bcb8-484f-982e-54425f9ac4de" />  | <img width="100"  alt="Screenshot 2025-08-16 at 18 12 18" src="https://github.com/user-attachments/assets/a982354c-f6ec-4f66-835e-f4308e4d62ee" /> | <img width="100"  alt="Screenshot 2025-08-16 at 18 13 09" src="https://github.com/user-attachments/assets/fb33b6f7-e0d6-4ce6-be98-3564db56eb28" /> | <img width="100"  alt="Screenshot 2025-08-16 at 18 11 47" src="https://github.com/user-attachments/assets/71c84ab7-bb45-40e2-8fa9-da0add693d32" /> |

Fixes issue #12 in the origin repo


